### PR TITLE
[feat] 매칭 도메인 및 엔티티 구조 변경 #1

### DIFF
--- a/src/main/java/com/grow/matching_service/matching/domain/enums/Age.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/enums/Age.java
@@ -1,0 +1,20 @@
+package com.grow.matching_service.matching.domain.enums;
+
+public enum Age {
+    TEENS("10대"),
+    TWENTIES("20대"),
+    THIRTIES("30대"),
+    FORTIES("40대"),
+    FIFTIES("50대"),
+    SIXTIES("60대 이상");
+
+    private final String description;
+
+    Age(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/domain/enums/Level.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/enums/Level.java
@@ -1,0 +1,31 @@
+package com.grow.matching_service.matching.domain.enums;
+
+public enum Level {
+    SEED(1, "씨앗", "완전히 초보자이며, 개념을 접하는 단계"),
+    SEEDLING(2, "새싹", "기초 지식을 쌓고 간단한 과제를 수행할 수 있는 단계"),
+    SAPLING(3, "나무", "일상적 활용이 가능하며, 문제 해결 경험을 쌓는 단계"),
+    BLOOMING(4, "꽃", "다양한 상황에서 능숙하게 적용하고 응용할 수 있는 단계"),
+    FRUITFUL(5, "열매", "전문가 수준으로 심화 내용까지 다룰 수 있는 단계");
+
+    private final int level;
+    private final String label;
+    private final String description;
+
+    Level(int level, String label, String description) {
+        this.level = level;
+        this.label = label;
+        this.description = description;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/domain/enums/MostActiveTime.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/enums/MostActiveTime.java
@@ -1,0 +1,15 @@
+package com.grow.matching_service.matching.domain.enums;
+
+// 자주 접속하는 시간을 Enum 타입으로 생성
+public enum MostActiveTime {
+    MORNING("아침 06:00 ~ 12:00"),
+    AFTERNOON("오후 12:00 ~ 18:00"),
+    EVENING("저녁 18:00 ~ 00:00"),
+    DAWN("새벽 00:00 ~ 06:00");
+
+    private final String description;
+
+    MostActiveTime(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/domain/model/Matching.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/model/Matching.java
@@ -1,8 +1,9 @@
 package com.grow.matching_service.matching.domain.model;
 
+import com.grow.matching_service.matching.domain.enums.Age;
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
 import lombok.Getter;
-
-import java.time.LocalDateTime;
 
 import com.grow.matching_service.matching.domain.enums.Category;
 
@@ -11,48 +12,89 @@ public class Matching {
     private final Long matchingId;
     private final Long memberId;
     private Category category;
-    private LocalDateTime mostActiveTime;
+    private Age age;
+    private MostActiveTime mostActiveTime;
+    private Level level;
     private Boolean isAttending;
     private String introduction;
 
-    private Matching(Long matchingId,
-                     Long memberId,
-                     Category category, // 추후에 DB 연결 후 교체 필요
-                     LocalDateTime mostActiveTime,
-                     Boolean isAttending,
-                     String introduction
-    ) {
-        this.matchingId = matchingId;
-        this.memberId = memberId;
-        this.category = category;
-        this.mostActiveTime = mostActiveTime;
-        this.isAttending = isAttending;
-        this.introduction = introduction;
-    }
-
-    public static Matching create(
-            Long memberId,
-            Category category,
-            LocalDateTime mostActiveTime,
-            Boolean isAttending,
-            String introduction
+    /** 신규 매칭 생성용 팩토리 */
+    public static Matching createNew(Long memberId,
+                                     Category category,
+                                     MostActiveTime mostActiveTime,
+                                     Level level,
+                                     Age age,
+                                     Boolean isAttending,
+                                     String introduction
     ) {
         return new Matching(
                 null,
                 memberId,
                 category,
                 mostActiveTime,
+                level,
+                age,
                 isAttending,
                 introduction
         );
+    }
+
+    /** DB 조회 (기존 매칭)용 팩토리 */
+    public static Matching loadExisting(Long matchingId,
+                                        Long memberId,
+                                        Category category,
+                                        MostActiveTime mostActiveTime,
+                                        Level level,
+                                        Age age,
+                                        Boolean isAttending,
+                                        String introduction
+    ) {
+        return new Matching(
+                matchingId,
+                memberId,
+                category,
+                mostActiveTime,
+                level,
+                age,
+                isAttending,
+                introduction
+        );
+    }
+
+    // private 생성자 통합
+    private Matching(Long matchingId,
+                     Long memberId,
+                     Category category,
+                     MostActiveTime mostActiveTime,
+                     Level level,
+                     Age age,
+                     Boolean isAttending,
+                     String introduction
+    ) {
+        this.matchingId      = matchingId;
+        this.memberId        = memberId;
+        this.category        = category;
+        this.mostActiveTime  = mostActiveTime;
+        this.level           = level;
+        this.age             = age;
+        this.isAttending     = isAttending;
+        this.introduction    = introduction;
     }
 
     public void updateCategory(Category newCategory) {
         this.category = newCategory;
     }
 
-    public void updateMostActiveTime(LocalDateTime newTime) {
-        this.mostActiveTime = newTime;
+    public void updateMostActiveTime(MostActiveTime newMostActiveTime) {
+        this.mostActiveTime = newMostActiveTime;
+    }
+
+    public void updateLevel(Level newLevel) {
+        this.level = newLevel;
+    }
+
+    public void updateAge(Age newAge) {
+        this.age = newAge;
     }
 
     public void updateAttendance(boolean attending) {
@@ -61,22 +103,5 @@ public class Matching {
 
     public void updateIntroduction(String newIntro) {
         this.introduction = newIntro;
-    }
-
-    public static Matching of(Long matchingId,
-                              Long memberId,
-                              Category category,
-                              LocalDateTime mostActiveTime,
-                              Boolean isAttending,
-                              String introduction
-    ) {
-        return new Matching(
-                matchingId,
-                memberId,
-                category,
-                mostActiveTime,
-                isAttending,
-                introduction
-        );
     }
 }

--- a/src/main/java/com/grow/matching_service/matching/infra/persistence/entity/MatchingJpaEntity.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/persistence/entity/MatchingJpaEntity.java
@@ -1,9 +1,10 @@
 package com.grow.matching_service.matching.infra.persistence.entity;
 
-import java.time.LocalDateTime;
-
+import com.grow.matching_service.matching.domain.enums.Age;
 import com.grow.matching_service.matching.domain.enums.Category;
 
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -26,10 +27,16 @@ public class MatchingJpaEntity {
 	private Category category;
 
 	@Column(nullable = false)
-	private LocalDateTime mostActiveTime;
+	private MostActiveTime mostActiveTime;
 
 	@Column(nullable = false)
-	private Boolean isAttending;
+	private Level level;
+
+	@Column(nullable = false)
+	private Age age;
+
+	@Column(nullable = false)
+	private Boolean isAttending; // 오프라인 모임 참석 여부
 
 	@Column(columnDefinition = "text")
 	private String introduction;
@@ -37,13 +44,17 @@ public class MatchingJpaEntity {
 	@Builder
 	public MatchingJpaEntity(Long memberId,
 							 Category category,
-							 LocalDateTime mostActiveTime,
+							 MostActiveTime mostActiveTime,
+							 Level level,
+							 Age age,
 							 Boolean isAttending,
 							 String introduction
 	) {
 		this.memberId = memberId;
 		this.category = category;
 		this.mostActiveTime = mostActiveTime;
+		this.level = level;
+		this.age = age;
 		this.isAttending = isAttending;
 		this.introduction = introduction;
 	}

--- a/src/main/java/com/grow/matching_service/matching/infra/persistence/mapper/MatchingMapper.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/persistence/mapper/MatchingMapper.java
@@ -5,26 +5,36 @@ import com.grow.matching_service.matching.infra.persistence.entity.MatchingJpaEn
 
 public class MatchingMapper {
 
-	// 엔티티를 도메인으로 변경
+	/**
+	 * 엔티티 → 도메인 변환 (toDomain)
+	 * DB로부터 조회한 데이터를 도메인 객체로 가져와 비즈니스 로직에서 사용
+	 */
 	public static Matching toDomain(MatchingJpaEntity entity) {
-		return Matching.of(
-			entity.getMatchingId(),
-			entity.getMemberId(),
-			entity.getCategory(),
-			entity.getMostActiveTime(),
-			entity.getIsAttending(),
-			entity.getIntroduction()
+		return Matching.loadExisting(
+				entity.getMatchingId(),
+				entity.getMemberId(),
+				entity.getCategory(),
+				entity.getMostActiveTime(),
+				entity.getLevel(),
+				entity.getAge(),
+				entity.getIsAttending(),
+				entity.getIntroduction()
 		);
 	}
 
-	// 도메인을 엔티티로 변경
+	/**
+	 * 도메인 → 엔티티 변환(toEntity)
+	 * 새로운 도메인 객체를 생성하거나 변경된 도메인 상태를 DB에 반영
+	 */
 	public static MatchingJpaEntity toEntity(Matching domain) {
 		return MatchingJpaEntity.builder()
-			.memberId(domain.getMemberId())
-			.category(domain.getCategory())
-			.mostActiveTime(domain.getMostActiveTime())
-			.isAttending(domain.getIsAttending())
-			.introduction(domain.getIntroduction())
-			.build();
+				.memberId(domain.getMemberId())
+				.category(domain.getCategory())
+				.mostActiveTime(domain.getMostActiveTime())
+				.level(domain.getLevel())
+				.isAttending(domain.getIsAttending())
+				.introduction(domain.getIntroduction())
+				.age(domain.getAge())
+				.build();
 	}
 }


### PR DESCRIPTION
## 🔗 Related Issues(필수)
Closes #{1}

## 📝 Note (변경 사항)

1. MostActiveTime 을 라디오 버튼 선택으로 받을 것을 고려하여 enum 타입으로 변경했습니다
2. 기존에 Level, Age 필드를 생성하지 않았던 것을 추가적으로 생성했습니다 (enum 타입)
3. 이에 맞추어 mapper, entity, domain 을 수정했습니다


