### PR TITLE
✨ feat: 매칭 서비스, 컨트롤러 로직 추가 #5 #6

### DIFF
--- a/src/main/java/com/grow/matching_service/matching/application/event/MatchingEventHandler.java
+++ b/src/main/java/com/grow/matching_service/matching/application/event/MatchingEventHandler.java
@@ -1,6 +1,6 @@
 package com.grow.matching_service.matching.application.event;
 
-import com.grow.matching_service.matching.domain.dto.MatchingResult;
+import com.grow.matching_service.matching.infra.dto.MatchingResult;
 import com.grow.matching_service.matching.domain.dto.event.MatchingSavedEvent;
 import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 import com.grow.matching_service.matching.infra.repository.MatchingQueryRepository;

--- a/src/main/java/com/grow/matching_service/matching/application/service/MatchingService.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/MatchingService.java
@@ -1,0 +1,7 @@
+package com.grow.matching_service.matching.application.service;
+
+import com.grow.matching_service.matching.persistence.dto.MatchingRequest;
+
+public interface MatchingService {
+    void createMatching(MatchingRequest request);
+}

--- a/src/main/java/com/grow/matching_service/matching/application/service/MatchingServiceImpl.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/MatchingServiceImpl.java
@@ -1,0 +1,44 @@
+package com.grow.matching_service.matching.application.service;
+
+import com.grow.matching_service.matching.persistence.dto.MatchingRequest;
+import com.grow.matching_service.matching.domain.model.Matching;
+import com.grow.matching_service.matching.domain.repository.MatchingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MatchingServiceImpl implements MatchingService {
+
+    private final MatchingRepository matchingRepository;
+
+    /**
+     * 매칭 정보를 저장하고, DB에 저장 -> 이벤트를 발행합니다.
+     *
+     * @param request 매칭 요청 DTO
+     */
+    @Override
+    @Transactional
+    public void createMatching(MatchingRequest request) {
+        // 도메인 생성
+        Matching matching = createNewDomain(request);
+
+        // 레포지토리에 저장
+        matchingRepository.save(matching);
+    }
+
+    private Matching createNewDomain(MatchingRequest request) {
+        return Matching.createNew(
+                request.getMemberId(),
+                request.getCategory(),
+                request.getMostActiveTime(),
+                request.getLevel(),
+                request.getAge(),
+                request.getIsAttending(),
+                request.getIntroduction()
+        );
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/infra/dto/MatchingResult.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/dto/MatchingResult.java
@@ -1,4 +1,4 @@
-package com.grow.matching_service.matching.domain.dto;
+package com.grow.matching_service.matching.infra.dto;
 
 import com.grow.matching_service.matching.domain.enums.Age;
 import com.grow.matching_service.matching.domain.enums.Category;

--- a/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepository.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepository.java
@@ -1,6 +1,6 @@
 package com.grow.matching_service.matching.infra.repository;
 
-import com.grow.matching_service.matching.domain.dto.MatchingResult;
+import com.grow.matching_service.matching.infra.dto.MatchingResult;
 import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 
 import java.util.List;

--- a/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepositoryImpl.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.grow.matching_service.matching.infra.repository;
 
-import com.grow.matching_service.matching.domain.dto.MatchingResult;
+import com.grow.matching_service.matching.infra.dto.MatchingResult;
 import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 import com.grow.matching_service.matching.infra.entity.QMatchingJpaEntity;
 import com.querydsl.core.types.Projections;

--- a/src/main/java/com/grow/matching_service/matching/persistence/controller/MatchingController.java
+++ b/src/main/java/com/grow/matching_service/matching/persistence/controller/MatchingController.java
@@ -1,0 +1,36 @@
+package com.grow.matching_service.matching.persistence.controller;
+
+import com.grow.matching_service.matching.application.service.MatchingService;
+import com.grow.matching_service.matching.persistence.dto.MatchingRequest;
+import com.grow.matching_service.rsdata.RsData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/matching")
+public class MatchingController {
+
+    private final MatchingService matchingService;
+
+    /**
+     * 매칭 정보를 저장합니다.
+     *
+     * @param request 매칭 요청 DTO
+     * @return 저장된 매칭 정보 DTO
+     */
+    @PostMapping("/save")
+    public RsData<String> createMatching(@RequestBody MatchingRequest request) {
+        matchingService.createMatching(request);
+
+        return new RsData<>(
+                "201",
+                "매칭 정보 생성 완료"
+        );
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/persistence/dto/MatchingRequest.java
+++ b/src/main/java/com/grow/matching_service/matching/persistence/dto/MatchingRequest.java
@@ -1,0 +1,21 @@
+package com.grow.matching_service.matching.persistence.dto;
+
+import com.grow.matching_service.matching.domain.enums.Age;
+import com.grow.matching_service.matching.domain.enums.Category;
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingRequest {
+    private Long memberId;
+    private Category category;
+    private MostActiveTime mostActiveTime;
+    private Level level;
+    private Age age;
+    private Boolean isAttending;
+    private String introduction;
+}

--- a/src/main/java/com/grow/matching_service/rsdata/RsData.java
+++ b/src/main/java/com/grow/matching_service/rsdata/RsData.java
@@ -1,0 +1,17 @@
+package com.grow.matching_service.rsdata;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RsData<T> {
+
+    private String code;
+    private String msg;
+    private T data;
+
+    public RsData(String code, String msg) {
+        this(code, msg, null);
+    }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료

현재는 컨트롤러, 서비스에 매칭을 받아서 저장하는 로직만 생성하였습니다
그래서 이번 pr 은 읽기 개쉽습니다 
이후에 추가적으로 수정할 수 있는 부분을 만들고, 더 이상의 매칭 알림이 오는 것을 원하지 않거나 + 혹은 매칭이 더는 되지 않았으면 한다 라고 했을 때 비활성화 하는 방식을 한 번 고려해 보는 것도 좋을 것 같습니다 (왜냐면 내가 이런 거 쓴다고 했을 때 이미 스터디 잘하고 있는데 자꾸 매칭 됐다고 알림 뜨면 너무 귀찮을 거 같음...) 
괜찮다면 멤버에 매칭 활성화 비활성화 boolean 값 하나만 넣어 보면 어떨까요!!! 기본 값은 true 로 하고, 나중에 마이 페이지에서 매칭 수정하면서 온오프 할 수 있게 하면 될 것 같음 ㅇㅋ 라면 erd 반영 해두겠습니다 👍
