### PR TITLE
✨ feat: 매칭 조회 로직 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,6 +120,7 @@ dependencies {
 tasks.named('test') {
 	outputs.dir snippetsDir
 	useJUnitPlatform()
+	maxHeapSize = "2048m"
 	finalizedBy jacocoTestReport
 }
 

--- a/src/main/java/com/grow/matching_service/matching/application/dto/MatchingResponse.java
+++ b/src/main/java/com/grow/matching_service/matching/application/dto/MatchingResponse.java
@@ -1,0 +1,39 @@
+package com.grow.matching_service.matching.application.dto;
+
+import com.grow.matching_service.matching.domain.enums.Age;
+import com.grow.matching_service.matching.domain.enums.Category;
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
+import com.grow.matching_service.matching.domain.model.Matching;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchingResponse {
+
+    private Long matchingId;
+    private Category category;
+    private MostActiveTime mostActiveTime;
+    private Level level;
+    private Age age;
+    private Boolean isAttending;
+    private String introduction;
+
+    // 도메인 객체를 DTO로 변환하는 정적 팩토리 메서드
+    public static MatchingResponse from(Matching matching) {
+        return MatchingResponse.builder()
+                .matchingId(matching.getMatchingId())
+                .category(matching.getCategory())
+                .mostActiveTime(matching.getMostActiveTime())
+                .level(matching.getLevel())
+                .age(matching.getAge())
+                .isAttending(matching.getIsAttending())
+                .introduction(matching.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/application/service/MatchingService.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/MatchingService.java
@@ -1,7 +1,12 @@
 package com.grow.matching_service.matching.application.service;
 
+import com.grow.matching_service.matching.application.dto.MatchingResponse;
+import com.grow.matching_service.matching.domain.enums.Category;
 import com.grow.matching_service.matching.presentation.dto.MatchingRequest;
+
+import java.util.List;
 
 public interface MatchingService {
     void createMatching(MatchingRequest request);
+    List<MatchingResponse> getMatchingsByCategory(Category category, Long memberId);
 }

--- a/src/main/java/com/grow/matching_service/matching/application/service/MatchingServiceImpl.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/MatchingServiceImpl.java
@@ -1,12 +1,16 @@
 package com.grow.matching_service.matching.application.service;
 
+import com.grow.matching_service.matching.application.dto.MatchingResponse;
+import com.grow.matching_service.matching.domain.enums.Category;
 import com.grow.matching_service.matching.presentation.dto.MatchingRequest;
 import com.grow.matching_service.matching.domain.model.Matching;
 import com.grow.matching_service.matching.domain.repository.MatchingRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -23,11 +27,59 @@ public class MatchingServiceImpl implements MatchingService {
     @Override
     @Transactional
     public void createMatching(MatchingRequest request) {
+        // 입력값 기본 검증 (나머지 필드에 대한 검증은 DTO 객체에서 실행)
+        if (request == null) {
+            throw new IllegalArgumentException("매칭 요청이 null 입니다.");
+        }
+
         // 도메인 생성
         Matching matching = createNewDomain(request);
 
         // 레포지토리에 저장
         matchingRepository.save(matching);
+    }
+
+    /**
+     * 카테고리와 회원 ID를 기준으로 매칭 정보를 조회합니다.
+     * @param category 조회할 카테고리
+     * @param memberId 조회할 회원 ID
+     * @return 매칭 정보 DTO 리스트
+     */
+    @Override
+    @Transactional(readOnly = true) // 조회용 -> 읽기 전용으로 설정
+    public List<MatchingResponse> getMatchingsByCategory(Category category,
+                                                         Long memberId) {
+        // 서비스 로직: 기본 null 체크만 (입력 필터링)
+        validateCategoryAndMemberId(category, memberId);
+
+        // 레포지토리에서 데이터를 조회 (최신 저장순 정렬) -> 도메인을 DTO 객체로 변환
+        List<MatchingResponse> responses = matchingRepository.findByCategoryAndMemberId(category, memberId)
+                .stream()
+                .map(MatchingResponse::from)
+                .toList();
+
+        // 단순 로깅 메서드
+        logging(category, memberId, responses);
+
+        return responses;
+    }
+
+    private void logging(Category category, Long memberId, List<MatchingResponse> responses) {
+        if (responses.isEmpty()) {
+            log.info("[MATCH] 해당 카테고리에 매칭 정보가 없습니다. - category: {}, memberId: {}", category, memberId);
+        } else {
+            log.info("[MATCH] 카테고리별 회원 매칭 조회 완료 - category: {}, memberId: {}, 조회된 건수: {}", category, memberId, responses.size());
+        }
+    }
+
+    private void validateCategoryAndMemberId(Category category, Long memberId) {
+        if (category == null) {
+            throw new IllegalArgumentException("카테고리는 null일 수 없습니다.");
+        }
+
+        if (memberId == null || memberId <= 0L) {
+            throw new IllegalArgumentException("유효하지 않은 회원 ID 입니다.");
+        }
     }
 
     private Matching createNewDomain(MatchingRequest request) {

--- a/src/main/java/com/grow/matching_service/matching/domain/exception/InvalidMatchingParameterException.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/exception/InvalidMatchingParameterException.java
@@ -1,0 +1,16 @@
+package com.grow.matching_service.matching.domain.exception;
+
+import com.grow.matching_service.matching.presentation.exception.ErrorCode;
+
+public class InvalidMatchingParameterException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public InvalidMatchingParameterException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/domain/model/Matching.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/model/Matching.java
@@ -3,9 +3,13 @@ package com.grow.matching_service.matching.domain.model;
 import com.grow.matching_service.matching.domain.enums.Age;
 import com.grow.matching_service.matching.domain.enums.Level;
 import com.grow.matching_service.matching.domain.enums.MostActiveTime;
+import com.grow.matching_service.matching.domain.exception.InvalidMatchingParameterException;
 import lombok.Getter;
 
 import com.grow.matching_service.matching.domain.enums.Category;
+
+import static com.grow.matching_service.matching.presentation.exception.ErrorCode.*;
+import static com.grow.matching_service.matching.presentation.exception.ErrorCode.INVALID_MATCHING_ID;
 
 @Getter
 public class Matching {
@@ -27,6 +31,10 @@ public class Matching {
                                      Boolean isAttending,
                                      String introduction
     ) {
+        // 도메인 생성 시 검증 필수
+        validateIntroduction(introduction);
+        validateRequiredFields(memberId, category, mostActiveTime, level, age); // 공통
+
         return new Matching(
                 null,
                 memberId,
@@ -49,6 +57,10 @@ public class Matching {
                                         Boolean isAttending,
                                         String introduction
     ) {
+        // 로드 시 기본 검증 (DB 데이터를 100% 신뢰하지 않는 것이 좋음)
+        validateMatchingId(matchingId); // ID 유효성 (제대로 생성이 됐는지)
+        validateRequiredFields(memberId, category, mostActiveTime, level, age);
+
         return new Matching(
                 matchingId,
                 memberId,
@@ -81,36 +93,51 @@ public class Matching {
         this.introduction    = introduction;
     }
 
-    // 검증 로직 추가
-    public void updateCategory(Category newCategory) {
-        if (newCategory == null) {
-            throw new IllegalArgumentException("카테고리는 null일 수 없습니다");
-        }
+    // 공통 검증: 필수 필드 null 체크
+    private static void validateRequiredFields(Long memberId,
+                                               Category category,
+                                               MostActiveTime mostActiveTime,
+                                               Level level,
+                                               Age age
+    ) {
+        checkMemberIdField(memberId);
+        checkCategoryField(category);
+        checkActiveTimeField(mostActiveTime);
+        checkLevelField(level);
+        checkAgeField(age);
+    }
 
+    // 생성 특유 검증 예시: introduction 규칙
+    private static void validateIntroduction(String introduction) {
+        if (introduction == null || introduction.isBlank() || introduction.length() > 1000) {
+            throw new InvalidMatchingParameterException(INVALID_INTRODUCTION);
+        }
+    }
+
+    // 로드 특유 검증: matchingId 유효성
+    private static void validateMatchingId(Long matchingId) {
+        if (matchingId == null || matchingId <= 0) {
+            throw new InvalidMatchingParameterException(INVALID_MATCHING_ID);
+        }
+    }
+
+    public void updateCategory(Category newCategory) {
+        checkCategoryField(newCategory);
         this.category = newCategory;
     }
 
     public void updateMostActiveTime(MostActiveTime newMostActiveTime) {
-        if (newMostActiveTime == null) {
-            throw new IllegalArgumentException("활동 시간은 null일 수 없습니다");
-        }
-
+        checkActiveTimeField(newMostActiveTime);
         this.mostActiveTime = newMostActiveTime;
     }
 
     public void updateLevel(Level newLevel) {
-        if (newLevel == null) {
-            throw new IllegalArgumentException("수준은 null일 수 없습니다");
-        }
-
+        checkLevelField(newLevel);
         this.level = newLevel;
     }
 
     public void updateAge(Age newAge) {
-        if (newAge == null) {
-            throw new IllegalArgumentException("나이는 null일 수 없습니다");
-        }
-
+        checkAgeField(newAge);
         this.age = newAge;
     }
 
@@ -119,6 +146,39 @@ public class Matching {
     }
 
     public void updateIntroduction(String newIntro) {
+        // 공백 체크 및 글자수 제한 추가
+        validateIntroduction(newIntro);
         this.introduction = newIntro;
     }
+
+    private static void checkAgeField(Age age) {
+        if (age == null) {
+            throw new InvalidMatchingParameterException(INVALID_AGE_ID);
+        }
+    }
+
+    private static void checkLevelField(Level level) {
+        if (level == null) {
+            throw new InvalidMatchingParameterException(INVALID_LEVEL_ID);
+        }
+    }
+
+    private static void checkMemberIdField(Long memberId) {
+        if (memberId == null || memberId <= 0L) {
+            throw new InvalidMatchingParameterException(INVALID_MEMBER_ID);
+        }
+    }
+
+    private static void checkActiveTimeField(MostActiveTime mostActiveTime) {
+        if (mostActiveTime == null) {
+            throw new InvalidMatchingParameterException(INVALID_MOST_ACTIVE_TIME_ID);
+        }
+    }
+
+    private static void checkCategoryField(Category category) {
+        if (category == null) {
+            throw new InvalidMatchingParameterException(INVALID_CATEGORY_ID);
+        }
+    }
+
 }

--- a/src/main/java/com/grow/matching_service/matching/domain/repository/MatchingRepository.java
+++ b/src/main/java/com/grow/matching_service/matching/domain/repository/MatchingRepository.java
@@ -1,13 +1,12 @@
 package com.grow.matching_service.matching.domain.repository;
 
 import java.util.List;
-import java.util.Optional;
 
+import com.grow.matching_service.matching.domain.enums.Category;
 import com.grow.matching_service.matching.domain.model.Matching;
 
 public interface MatchingRepository {
-	Matching save(Matching matching);
-	Optional<Matching> findById(Long matchingId);
+	void save(Matching matching);
 	List<Matching> findByMemberId(Long memberId);
-	void delete(Matching matching);
+	List<Matching> findByCategoryAndMemberId(Category category, Long memberId);
 }

--- a/src/main/java/com/grow/matching_service/matching/infra/init/MatchingDataInitializer.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/init/MatchingDataInitializer.java
@@ -12,7 +12,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
+// @Component
 @RequiredArgsConstructor
 public class MatchingDataInitializer implements CommandLineRunner {
 

--- a/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingJpaRepository.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingJpaRepository.java
@@ -2,6 +2,7 @@ package com.grow.matching_service.matching.infra.repository;
 
 import java.util.List;
 
+import com.grow.matching_service.matching.domain.enums.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
@@ -9,4 +10,13 @@ import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 public interface MatchingJpaRepository
 	extends JpaRepository<MatchingJpaEntity, Long> {
 	List<MatchingJpaEntity> findByMemberId(Long memberId);
+
+	/**
+	 * 카테고리와 회원 ID를 기준으로 매칭 정보를 조회합니다. (최신순 정렬)
+	 * @param category 조회할 카테고리
+	 * @param memberId 조회할 회원 ID
+	 * @return 매칭 정보 엔티티 리스트
+	 */
+    List<MatchingJpaEntity> findByCategoryAndMemberIdOrderByMatchingIdDesc(Category category,
+																		   Long memberId);
 }

--- a/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingRepositoryImpl.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingRepositoryImpl.java
@@ -1,18 +1,19 @@
 package com.grow.matching_service.matching.infra.repository;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.grow.matching_service.matching.domain.enums.Category;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import com.grow.matching_service.matching.domain.model.Matching;
 import com.grow.matching_service.matching.domain.repository.MatchingRepository;
-import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 import com.grow.matching_service.matching.infra.mapper.MatchingMapper;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class MatchingRepositoryImpl implements MatchingRepository {
@@ -20,26 +21,30 @@ public class MatchingRepositoryImpl implements MatchingRepository {
 	private final MatchingJpaRepository matchingJpaRepository;
 
 	@Override
-	public Matching save(Matching matching) {
-		MatchingJpaEntity saved = matchingJpaRepository.save(MatchingMapper.toEntity(matching));
-		return MatchingMapper.toDomain(saved);
-	}
-
-	@Override
-	public Optional<Matching> findById(Long matchingId) {
-		return matchingJpaRepository.findById(matchingId)
-			.map(MatchingMapper::toDomain);
+	public void save(Matching matching) {
+		matchingJpaRepository.save(MatchingMapper.toEntity(matching));
+		log.info("[MATCH] 매칭 정보 저장 완료 - memberId: {}", matching.getMemberId());
 	}
 
 	@Override
 	public List<Matching> findByMemberId(Long memberId) {
 		return matchingJpaRepository.findByMemberId(memberId).stream()
-			.map(MatchingMapper::toDomain)
-			.collect(Collectors.toList());
+				.map(MatchingMapper::toDomain)
+				.collect(Collectors.toList());
 	}
 
+	/**
+	 * 카테고리와 회원 ID를 기준으로 매칭 정보를 조회합니다. (최신순 정렬)
+	 * @param category 조회할 카테고리
+	 * @param memberId 조회할 회원 ID
+	 * @return 매칭 정보 리스트
+	 */
 	@Override
-	public void delete(Matching matching) {
-		matchingJpaRepository.delete(MatchingMapper.toEntity(matching));
+	public List<Matching> findByCategoryAndMemberId(Category category,
+													Long memberId) {
+        return matchingJpaRepository
+                .findByCategoryAndMemberIdOrderByMatchingIdDesc(category, memberId).stream()
+                .map(MatchingMapper::toDomain)
+                .collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/grow/matching_service/matching/presentation/controller/MatchingController.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/controller/MatchingController.java
@@ -1,15 +1,16 @@
 package com.grow.matching_service.matching.presentation.controller;
 
+import com.grow.matching_service.matching.application.dto.MatchingResponse;
 import com.grow.matching_service.matching.application.service.MatchingService;
+import com.grow.matching_service.matching.domain.enums.Category;
 import com.grow.matching_service.matching.presentation.dto.MatchingRequest;
-import com.grow.matching_service.common.rsdata.RsData;
+import com.grow.matching_service.matching.presentation.dto.rsdata.RsData;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -23,7 +24,6 @@ public class MatchingController {
      * 매칭 정보를 저장합니다.
      *
      * @param request 매칭 요청 DTO
-     * @return 저장된 매칭 정보 DTO
      */
     @PostMapping("/save")
     public RsData<String> createMatching(@Valid @RequestBody MatchingRequest request) {
@@ -32,6 +32,28 @@ public class MatchingController {
         return new RsData<>(
                 "201",
                 "매칭 정보 생성 완료"
+        );
+    }
+
+    /**
+     * 카테고리를 기준으로 특정 회원의 매칭 정보를 전체 조회합니다.
+     *
+     * @param category 조회할 카테고리
+     * @param memberId 조회할 회원 ID
+     * @return 매칭 정보 DTO 리스트
+     */
+    @GetMapping("/check")
+    public RsData<List<MatchingResponse>> getAllMatching(@RequestParam("category") Category category,
+                                                         @RequestParam("memberId") Long memberId) {
+        log.info("[MATCH] 카테고리별 회원 매칭 목록 조회 요청 - category: {}, memberId: {}",
+                category, memberId);
+
+        List<MatchingResponse> responses = matchingService.getMatchingsByCategory(category, memberId);
+
+        return new RsData<>(
+                "200",
+                "회원별 매칭 정보 조회 완료",
+                responses
         );
     }
 }

--- a/src/main/java/com/grow/matching_service/matching/presentation/dto/MatchingRequest.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/dto/MatchingRequest.java
@@ -1,0 +1,33 @@
+package com.grow.matching_service.matching.presentation.dto;
+
+import com.grow.matching_service.matching.domain.enums.Age;
+import com.grow.matching_service.matching.domain.enums.Category;
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchingRequest {
+
+    @NotNull(message = "회원 ID는 필수입니다.")
+    private Long memberId;
+    @NotNull(message = "카테고리는 필수입니다.")
+    private Category category;
+    @NotNull(message = "활동 시간은 필수입니다.")
+    private MostActiveTime mostActiveTime;
+    @NotNull(message = "레벨은 필수입니다.")
+    private Level level;
+    @NotNull(message = "나이는 필수입니다.")
+    private Age age;
+    @NotNull(message = "오프라인 모임 참석 여부는 필수입니다.")
+    private Boolean isAttending;
+    @NotBlank(message = "소개글은 필수입니다.")
+    @Size(min = 10, max = 500, message = "소개글은 10자 이상 500자 이하로 작성해주세요.")
+    private String introduction;
+}

--- a/src/main/java/com/grow/matching_service/matching/presentation/exception/ErrorCode.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.grow.matching_service.matching.presentation.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    INVALID_MATCHING_ID("400", "유효하지 않은 매칭 ID 값입니다."),
+    INVALID_CATEGORY_ID("400", "유효하지 않은 카테고리 값입니다." ),
+    INVALID_MOST_ACTIVE_TIME_ID("400", "유효하지 않은 활동 시간 값입니다."),
+    INVALID_LEVEL_ID("400", "유효하지 않은 레벨 값입니다."),
+    INVALID_AGE_ID("400", "유효하지 않은 나이 값입니다."),
+    INVALID_INTRODUCTION("400", "유효하지 않은 소개글 값입니다."),
+    INVALID_MEMBER_ID("400", "유효하지 않은 회원 ID 값입니다." ),
+    ;
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/grow/matching_service/matching/presentation/exception/ErrorResponse.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/exception/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.grow.matching_service.matching.presentation.exception;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private Integer status;
+    private String errorCode; // 에러 코드
+    private String message;
+    private List<String> error; // validation 오류 목록
+    private String path; // 에러 발생 경로
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(Integer status,
+                         String errorCode,
+                         String message,
+                         String path,
+                         LocalDateTime timestamp
+    ) {
+        this.status = status;
+        this.errorCode = errorCode;
+        this.message = message;
+        this.path = path;
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,71 @@
+package com.grow.matching_service.matching.presentation.exception;
+
+import com.grow.matching_service.matching.domain.exception.InvalidMatchingParameterException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 검증 실패 처리 (@RequestBody)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e,
+                                                               HttpServletRequest request) {
+        log.error("[Validation ERROR] 메서드 파라미터 유효성 검증 실패: {}", e.getMessage());
+
+        List<String> errors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .toList();
+
+        return ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .errorCode("VALIDATION_FAILED")
+                .message("입력값 검증에 실패했습니다.")
+                .error(errors)
+                .path(request.getRequestURI())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    // 도메인 커스텀 예외 처리 (InvalidMatchingParameterException)
+    @ExceptionHandler(InvalidMatchingParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleInvalidMatchingParameterException(InvalidMatchingParameterException ex,
+                                                                 HttpServletRequest request) {
+        log.error("[Domain ERROR] 매칭 파라미터 오류: {}", ex.getMessage());
+        return ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .errorCode(ex.getErrorCode().toString()) // 각 코드를 불러옴
+                .message(ex.getMessage())
+                .path(request.getRequestURI())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+
+    // 일반 예외 fallback
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleGenericException(Exception ex, HttpServletRequest request) {
+        log.error("[SERVER ERROR] 예기치 못한 서버 오류: {}", ex.getMessage(), ex);
+        return ErrorResponse.builder()
+                .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .errorCode("INTERNAL_ERROR")
+                .message("예기치 못한 서버 오류가 발생했습니다.")
+                .error(List.of(ex.getMessage()))
+                .path(request.getRequestURI())
+                .timestamp(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/grow/matching_service/matching/application/service/MatchingServiceImplTest.java
+++ b/src/test/java/com/grow/matching_service/matching/application/service/MatchingServiceImplTest.java
@@ -34,7 +34,7 @@ class MatchingServiceImplTest {
     void createMatching() throws Exception {
         //given
         MatchingRequest request = new MatchingRequest(
-                6L,
+                1L,
                 Category.STUDY,
                 MostActiveTime.EVENING,
                 Level.BLOOMING,
@@ -47,7 +47,7 @@ class MatchingServiceImplTest {
         matchingService.createMatching(request);
 
         //then
-        assertThat(matchingRepository.findByMemberId(6L).getFirst().getIntroduction())
+        assertThat(matchingRepository.findByMemberId(1L).getFirst().getIntroduction())
                 .isEqualTo("[TEST1]안녕하세요");
 
         Matching savedMatching = matchingRepository.findByMemberId(1L).getFirst();

--- a/src/test/java/com/grow/matching_service/matching/application/service/MatchingServiceImplTest.java
+++ b/src/test/java/com/grow/matching_service/matching/application/service/MatchingServiceImplTest.java
@@ -34,7 +34,7 @@ class MatchingServiceImplTest {
     void createMatching() throws Exception {
         //given
         MatchingRequest request = new MatchingRequest(
-                1L,
+                6L,
                 Category.STUDY,
                 MostActiveTime.EVENING,
                 Level.BLOOMING,
@@ -47,7 +47,7 @@ class MatchingServiceImplTest {
         matchingService.createMatching(request);
 
         //then
-        assertThat(matchingRepository.findByMemberId(1L).getFirst().getIntroduction())
+        assertThat(matchingRepository.findByMemberId(6L).getFirst().getIntroduction())
                 .isEqualTo("[TEST1]안녕하세요");
 
         Matching savedMatching = matchingRepository.findByMemberId(1L).getFirst();


### PR DESCRIPTION

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인

<img width="531" height="216" alt="스크린샷 2025-07-18 오후 8 18 33" src="https://github.com/user-attachments/assets/c3bdf8cf-5502-422f-adb6-b0408a4dc151" />

- 도메인에서 제대로 값이 들어가는지, 제대로 값을 가져오는지 테스트 하는 코드 통과

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행
    2. http://localhost:8080/api/matching/check?category=HOBBY&memberId=6 위와 같은 식으로 요청 전송
    3. 성공 메시지 확인

<img width="728" height="739" alt="스크린샷 2025-07-18 오후 7 56 48" src="https://github.com/user-attachments/assets/1bf0af06-389a-414e-a1b3-e1374c7e6794" />

- 조회할 정보가 있을 경우

<img width="728" height="588" alt="스크린샷 2025-07-18 오후 8 02 22" src="https://github.com/user-attachments/assets/b4b03014-bd15-4503-b951-8f407437a990" />
<img width="695" height="146" alt="스크린샷 2025-07-18 오후 8 02 36" src="https://github.com/user-attachments/assets/6cad103b-3dd6-43cd-b8c6-ffaa8b366a58" />

- 조회할 정보가 없는 경우

<img width="1608" height="331" alt="스크린샷 2025-07-18 오후 8 02 06" src="https://github.com/user-attachments/assets/0152a4a4-2e19-42fe-bc8a-ca61025b97ca" />

- 데이터 이니셜라이저로 등록한 후, 제대로 이벤트를 발행하는지 로그로 확인



## 📝 Note (주의 사항)
1. 멤버 ID 는 추후에 어떻게 넘어올지 몰라 일단 파라미터로 넘기는 방식으로 구현했습니다
2. 조회할 정보가 없는 경우 예외를 던질까 했는데, 없는 경우가 오류는 아니라서 오류로 처리하는 것보다 빈 리스트가 전달될 경우 클라이언트에서 없다는 식으로 보여 주는 게 더 요즘 방식이라고 하길래 (...) 빈 리스트 반환하는 걸로 처리했습니다 
3. 도메인 로직에서 제대로 된 값이 들어오고 나가는지 확인을 하고 서비스 레이어에서는 예외 전파 혹은 로직 중 오류가 발생했을 때 던지는 역할 < 이런 식으로 생각했습니다
그래서 도메인 로직에 커스텀 예외 추가하고 핸들러는 프레젠테이션 계층에 두었어요 

첨언 환영