### PR TITLE
✨ feat: 매칭 성공 시 알림 전송 기능 구현 #20

### DIFF
--- a/src/main/java/com/grow/matching_service/MatchingServiceApplication.java
+++ b/src/main/java/com/grow/matching_service/MatchingServiceApplication.java
@@ -2,14 +2,15 @@ package com.grow.matching_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
+@EnableFeignClients
 @SpringBootApplication
 public class MatchingServiceApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(MatchingServiceApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/grow/matching_service/matching/application/dto/NotificationRequestDto.java
+++ b/src/main/java/com/grow/matching_service/matching/application/dto/NotificationRequestDto.java
@@ -1,0 +1,19 @@
+package com.grow.matching_service.matching.application.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 알림 전송을 위한 DTO 클래스 (임시)
+ */
+@Getter
+@Builder
+public class NotificationRequestDto {
+
+    private Long memberId;
+    private String content;
+    private String notificationType; // 알림 타입 MATCH
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/grow/matching_service/matching/application/event/MatchingEventHandler.java
+++ b/src/main/java/com/grow/matching_service/matching/application/event/MatchingEventHandler.java
@@ -1,10 +1,11 @@
 package com.grow.matching_service.matching.application.event;
 
+import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
 import com.grow.matching_service.matching.infra.dto.MatchingQueryDto;
 import com.grow.matching_service.matching.infra.dto.MatchingResult;
 import com.grow.matching_service.matching.domain.dto.event.MatchingSavedEvent;
-import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
 import com.grow.matching_service.matching.infra.repository.MatchingQueryRepository;
+import com.grow.matching_service.matching.presentation.client.NotificationServiceClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -14,16 +15,50 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 /**
- * TODO DTO 를 받아서 사용하는 방식으로 코드 수정 필요함
+ * 매칭 이벤트 핸들러 클래스.
+ * <p>
+ * 이 클래스는 매칭 저장 이벤트({@link MatchingSavedEvent})를 처리하여,
+ * 매칭된 사용자들을 조회하고 알림을 전송합니다. Spring의 이벤트 리스너 메커니즘을 활용합니다.
+ *
+ * @author sun
+ * @since 1.0
+ * @see MatchingSavedEvent
+ * @see MatchingQueryRepository
+ * @see NotificationServiceClient
  */
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class MatchingEventHandler {
 
+    /**
+     * 매칭 쿼리 리포지토리.
+     * <p>
+     * 매칭 조건에 맞는 사용자 목록을 조회하는 데 사용됩니다.
+     */
     private final MatchingQueryRepository queryRepository;
+    /**
+     * 알림 서비스 클라이언트.
+     * <p>
+     * 매칭 성공 시 사용자에게 알림을 전송하는 Feign 클라이언트입니다.
+     */
+    private final NotificationServiceClient notificationService;
 
-    @Async // 트랜잭션 도입 필요할 시 트랜잭션 경계 고려 필요
+    /**
+     * 매칭 저장 이벤트를 비동기적으로 처리합니다.
+     * <p>
+     * 이벤트에서 받은 {@link MatchingQueryDto}를 기반으로 매칭 사용자 목록을 조회하고,
+     * 본인과 상대방에게 각각 알림을 전송합니다. 매칭 대상이 없을 경우 로그를 남기고 종료합니다.
+     * <p>
+     * 이 메서드는 Spring의 {@link EventListener}를 통해 이벤트 구독을 처리하며,
+     * {@link Async}로 비동기 실행됩니다.
+     *
+     * @param event 매칭 저장 이벤트 객체 ({@link MatchingSavedEvent})
+     * @see MatchingSavedEvent
+     * @see MatchingQueryRepository#findMatchingUsers(MatchingQueryDto)
+     */
+    @Async
     @EventListener
     public void handleMatchingSaved(MatchingSavedEvent event) {
         MatchingQueryDto reference = event.getDto();
@@ -31,18 +66,69 @@ public class MatchingEventHandler {
 
         // 빈 리스트 추출 시 예외 처리
         if (matchingUsers.isEmpty()) {
-            log.info("[MATCH] 매칭 대상이 없습니다. memberId: {}",
-                    reference.getMemberId());
+            log.info("[MATCH] 매칭 대상이 없습니다. memberId: {}", reference.getMemberId());
             return;
         }
 
-        // TODO: 비즈니스 로직 처리 (알림 발송, 집계 or 사용자에게 매칭 정보 전송 등)
+        sendNotificationOwn(reference, matchingUsers);
+
         for (MatchingResult matchingUser : matchingUsers) {
-            log.info("[MATCH] 현재 사용자 {} 와 유사한 조건의 사용자 {} - 유사도: {}점",
-                    reference.getMemberId(),
-                    matchingUser.getMemberId(),
-                    matchingUser.getScore()
-            );
+            logging(matchingUser, reference);
+            sendNotificationOthers(matchingUser, reference);
         }
+    }
+
+    /**
+     * 매칭 성공 시 본인에게 알림을 전송합니다.
+     * <p>
+     * 매칭된 사용자 수를 요약하여 "MATCH_SUCCESS" 타입의 알림을 보냅니다.
+     *
+     * @param reference 본인 매칭 쿼리 DTO ({@link MatchingQueryDto})
+     * @param matchingUsers 매칭된 사용자 목록 ({@link List}<{@link MatchingResult}>)
+     * @see NotificationServiceClient#sendNotification(NotificationRequestDto)
+     */
+    private void sendNotificationOwn(MatchingQueryDto reference,
+                                     List<MatchingResult> matchingUsers) {
+        // 매칭 성공 시 본인에게 알림 전송 (매칭 목록 요약)
+        notificationService.sendNotification(NotificationRequestDto.builder()
+                .memberId(reference.getMemberId())
+                .content("매칭 성공! " + matchingUsers.size() + "명의 사용자와 매칭되었습니다.")
+                .notificationType("MATCH_SUCCESS")
+                .build());
+    }
+
+    /**
+     * 매칭 성공 시 각 상대방에게 알림을 전송합니다.
+     * <p>
+     * 본인 ID와 유사도 점수를 포함한 "MATCH_SUCCESS" 타입의 알림을 보냅니다.
+     *
+     * @param matchingUser 매칭된 상대방 결과 DTO ({@link MatchingResult})
+     * @param reference 본인 매칭 쿼리 DTO ({@link MatchingQueryDto})
+     * @see NotificationServiceClient#sendNotification(NotificationRequestDto)
+     */
+    private void sendNotificationOthers(MatchingResult matchingUser,
+                                        MatchingQueryDto reference) {
+        notificationService.sendNotification(NotificationRequestDto.builder()
+                .memberId(matchingUser.getMemberId())
+                .content("새로운 매칭! 사용자 " + reference.getMemberId() + "와 매칭되었습니다. " +
+                        "유사도: " + matchingUser.getScore() + "점")
+                .notificationType("MATCH_SUCCESS")
+                .build());
+    }
+
+    /**
+     * 매칭 결과를 로그로 기록합니다.
+     * <p>
+     * 본인 ID, 상대방 ID, 유사도 점수를 INFO 레벨로 로그합니다.
+     *
+     * @param matchingUser 매칭된 상대방 결과 DTO ({@link MatchingResult})
+     * @param reference 본인 매칭 쿼리 DTO ({@link MatchingQueryDto})
+     */
+    private void logging(MatchingResult matchingUser, MatchingQueryDto reference) {
+        log.info("[MATCH] 현재 사용자 {} 와 유사한 조건의 사용자 {} - 유사도: {}점",
+                reference.getMemberId(),
+                matchingUser.getMemberId(),
+                matchingUser.getScore()
+        );
     }
 }

--- a/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationServiceClient.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationServiceClient.java
@@ -1,0 +1,20 @@
+package com.grow.matching_service.matching.presentation.client;
+
+import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * @FeignClient 클라이언트 이름과 URL을 지정
+ * 1. NotificationServiceClient 를 @Autowired
+ * 2. sendNotification 메서드 호출하면서 dto 를 전송하면
+ * 3. 자동으로 notification-service 에게 요청을 보낸다
+ */
+@FeignClient(name = "notification-service",
+        url = "${notification.service.url}")
+public interface NotificationServiceClient {
+
+    @PostMapping("/notifications")
+    void sendNotification(@RequestBody NotificationRequestDto request);
+}


### PR DESCRIPTION

## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)
<img width="529" height="120" alt="스크린샷 2025-07-23 오전 11 38 23" src="https://github.com/user-attachments/assets/30fc6643-54ec-4da5-801a-f342cfc3f28e" />

## 📝 Note (주의 사항)
추후에 실제 notification-service 와 연동해서 제대로 전송이 되는지 확인해 볼 필요는 있을 듯 합니다
서버간의 통신을 위한 용도라서 notification 에서 클라이언트로 전송하는 것은 또 별개의 문제라고 하네요 ^^!
서버로 전송하고, 수신해서 DB로 저장, 클라이언트에 sse 로 전송 이런 식으로 로직 구현하면 될 것 같습니다
