### PR TITLE
✨ feat: 재전송을 위한 큐 서비스 및 fallback 팩토리 클래스 구현

### DIFF
--- a/src/main/java/com/grow/matching_service/matching/application/config/RedisConfig.java
+++ b/src/main/java/com/grow/matching_service/matching/application/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.grow.matching_service.matching.application.config;
+
+import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, NotificationRequestDto> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, NotificationRequestDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // 키 직렬화 설정 (직렬화/역직렬화 모두 처리)
+        template.setKeySerializer(new StringRedisSerializer());
+        // 값 직렬화 설정 (직렬화/역직렬화 모두 처리, 필요 시 JSON 직렬화기로 변경)
+        template.setValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/application/dto/NotificationRequestDto.java
+++ b/src/main/java/com/grow/matching_service/matching/application/dto/NotificationRequestDto.java
@@ -6,14 +6,70 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 /**
- * 알림 전송을 위한 DTO 클래스 (임시)
+ * 알림 전송을 위한 DTO 클래스.
+ * 이 DTO는 알림 요청 데이터를 캡슐화하며, 멤버 ID, 내용, 타입, 타임스탬프, 재시도 횟수를 포함합니다.
+ * 주로 NotificationServiceClient나 QueueService에서 사용되어 장애 시 재시도 로직을 지원합니다.
+ *
+ * <p>이 클래스는 Lombok의 @Getter와 @Builder를 사용하여 간편한 객체 생성과 접근을 제공합니다.
+ * retryCount 필드는 알림 전송 실패 시 증가되며, 재시도 한계를 관리할 수 있습니다.</p>
+ *
+ * @see java.time.LocalDateTime
  */
 @Getter
-@Builder
 public class NotificationRequestDto {
 
-    private Long memberId;
-    private String content;
-    private String notificationType; // 알림 타입 MATCH
-    private LocalDateTime timestamp;
+    /**
+     * 알림을 받을 멤버의 고유 ID.
+     */
+    private final Long memberId;
+
+    /**
+     * 알림 내용 (텍스트 메시지).
+     */
+    private final String content;
+
+    /**
+     * 알림 타입 (예: "MATCH_SUCCESS" 등).
+     */
+    private final String notificationType;
+
+    /**
+     * 알림 생성 타임스탬프.
+     */
+    private final LocalDateTime timestamp;
+
+    /**
+     * 재시도 횟수 (초기값 0, 실패 시 증가).
+     */
+    private int retryCount;
+
+    /**
+     * NotificationRequestDto의 빌더 생성자.
+     * 필수 필드를 초기화하며, retryCount는 기본값 0으로 설정됩니다.
+     *
+     * @param memberId 알림 대상 멤버 ID
+     * @param content 알림 내용
+     * @param notificationType 알림 타입 (예: "MATCH_SUCCESS")
+     * @param timestamp 알림 타임스탬프
+     */
+    @Builder
+    public NotificationRequestDto(Long memberId,
+                                  String content,
+                                  String notificationType,
+                                  LocalDateTime timestamp) {
+        this.memberId = memberId;
+        this.content = content;
+        this.notificationType = notificationType;
+        this.timestamp = timestamp;
+        this.retryCount = 0;  // 초기 재시도 횟수 설정
+    }
+
+    /**
+     * 재시도 횟수를 증가시킵니다.
+     * 알림 전송 실패 시 호출되어 retryCount를 1 증가시킵니다.
+     * 이는 \큐 기반 재시도 로직에서 사용됩니다.
+     */
+    public void increaseRetryCount() {
+        this.retryCount++;  // 재시도 횟수 증가
+    }
 }

--- a/src/main/java/com/grow/matching_service/matching/application/service/NotificationRetryService.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/NotificationRetryService.java
@@ -1,0 +1,82 @@
+package com.grow.matching_service.matching.application.service;
+
+import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
+import com.grow.matching_service.matching.presentation.client.NotificationServiceClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * 알림 재전송을 위한 스케줄링 서비스 클래스.
+ * Redis 큐에 저장된 알림 요청을 주기적으로 dequeue하여 재전송을 시도합니다.
+ * 이는 Notification 서비스의 장애 시 fallback으로 저장된 요청을 처리하기 위한 목적으로 사용됩니다.
+ *
+ * <p>이 서비스는 Spring의 {@link Scheduled} 어노테이션을 사용하여 주기적으로 실행되며,
+ * 큐에서 요청을 꺼내 재전송을 시도합니다. 재시도 횟수가 초과된 경우 경고 로그를 남기고 스킵합니다.</p>
+ *
+ * <p>의존성:
+ * <ul>
+ *     <li>{@link QueueService}: Redis 큐 관리를 위한 서비스</li>
+ *     <li>{@link NotificationServiceClient}: 알림 전송을 위한 Feign 클라이언트</li>
+ * </ul>
+ * </p>
+ *
+ * @see QueueService
+ * @see NotificationServiceClient
+ * @see org.springframework.scheduling.annotation.Scheduled
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationRetryService {
+
+    private final QueueService queueService;
+    private final NotificationServiceClient notificationServiceClient;
+
+    /**
+     * Redis 큐에 저장된 알림 요청을 10분마다 재전송 시도하는 스케줄링 메서드.
+     *
+     * <p>이 메서드는 {@link Scheduled} 어노테이션에 의해 fixedRate(고정 간격)로 실행됩니다.
+     * 큐에서 요청을 dequeue하여 {@link NotificationServiceClient#sendNotification(NotificationRequestDto)}를 호출합니다.
+     * 성공 시 로그를 남기고 루프를 종료합니다. 실패 시 재시도 횟수를 증가시키고 큐에 다시 enqueue 합니다.</p>
+     *
+     * <p>동작 순서:
+     * <ol>
+     *     <li>큐가 비어 있을 때까지 while 루프로 dequeue를 반복합니다.</li>
+     *     <li>재시도 횟수가 3회 이상이면 경고 로그를 남기고 스킵합니다.</li>
+     *     <li>전송 시도 중 예외 발생 시 큐에 다시 추가합니다.</li>
+     * </ol>
+     * </p>
+     *
+     * @see org.springframework.scheduling.annotation.Scheduled#fixedRate()
+     * @see QueueService#dequeueNotification()
+     * @see QueueService#enqueueNotification(NotificationRequestDto)
+     * @see NotificationServiceClient#sendNotification(NotificationRequestDto)
+     */
+    @Scheduled(fixedRate = 60000 * 10) // 10분마다 실행
+    public void retryNotifications() {
+        NotificationRequestDto request;
+        while ((request = queueService.dequeueNotification()) != null) {
+            if (checkRetryCount(request)) continue;
+            log.info("Redis 큐에서 알림 재전송 중: {}", request.getContent());
+            try {
+                notificationServiceClient.sendNotification(request);
+                log.info("[Notification] Redis 큐에서 알림 재전송 성공: {}", request.getContent());
+            } catch (Exception e) {
+                log.error("[Notification] 재전송 실패, 큐에 다시 추가");
+                request.increaseRetryCount(); // 재시도 횟수 증가
+                queueService.enqueueNotification(request); // 재전송 실패시 큐에 다시 추가
+            }
+        }
+    }
+
+    private boolean checkRetryCount(NotificationRequestDto request) {
+        if (request.getRetryCount() >= 3) { // 최대 3회 제한
+            log.warn("[Notification] 재시도 횟수 초과: {}", request.getContent());
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/application/service/QueueService.java
+++ b/src/main/java/com/grow/matching_service/matching/application/service/QueueService.java
@@ -1,0 +1,96 @@
+package com.grow.matching_service.matching.application.service;
+
+import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * Redis를 사용해 오류로 인해 전송되지 못한 알림 메시지를 저장하는 서비스 클래스.
+ * Queue 구조를 이용하여 FIFO(First-In-First-Out) 방식으로 요청을 관리합니다.
+ *
+ * <p>이 서비스는 알림 전송 실패 시 fallback으로 요청을 Redis 리스트에 저장하고,
+ * 나중에 dequeue하여 재전송할 수 있도록 지원합니다. Spring의 {@link RedisTemplate}을 활용하며,
+ * 비동기 처리({@link Async})를 통해 효율성을 높입니다.</p>
+ *
+ * <p>의존성:
+ * <ul>
+ *     <li>{@link RedisTemplate}: Redis 리스트 조작을 위한 템플릿</li>
+ * </ul>
+ * </p>
+ *
+ * @see RedisTemplate
+ * @see org.springframework.scheduling.annotation.Async
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+    private final RedisTemplate<String, NotificationRequestDto> redisTemplate;
+    private static final String QUEUE_KEY = "notification-queue"; // 추후 분리를 할지 고려해 보겠음...
+
+    /**
+     * 알림 요청을 Redis 큐에 비동기적으로 추가하는 메서드.
+     *
+     * <p>이 메서드는 {@link Async} 어노테이션에 의해 비동기 스레드에서 실행됩니다.
+     * Redis 리스트의 왼쪽에 요청을 푸시(LPUSH)하여 FIFO 순서를 유지합니다.
+     * 성공 시 정보 로그를 남기고, 실패 시 에러 로그를 기록합니다.</p>
+     *
+     * <p>동작 순서:
+     * <ol>
+     *     <li>RedisTemplate의 opsForList().leftPush()를 호출하여 큐에 추가합니다.</li>
+     *     <li>예외 발생 시 catch 블록에서 로그만 처리합니다.</li>
+     * </ol>
+     * </p>
+     *
+     * @param request 큐에 추가할 알림 요청 DTO (null 불가)
+     * @see org.springframework.scheduling.annotation.Async
+     * @see RedisTemplate#opsForList()
+     */
+    @Async // 비동기로 메시지를 저장
+    public void enqueueNotification(NotificationRequestDto request) {
+        try {
+            redisTemplate.opsForList().leftPush(QUEUE_KEY, request);
+            log.info("알림 요청을 Redis 큐에 추가: {}", request.getContent());
+        } catch (Exception e) {
+            log.error("Redis 큐 추가 실패: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Redis 큐에서 알림 요청을 꺼내는 메서드.
+     *
+     * <p>이 메서드는 Redis 리스트의 오른쪽에서 팝(RPOP)하여 가장 오래된 요청을 반환합니다.
+     * 요청이 존재할 경우 정보 로그를 남기고, 실패 시 에러 로그를 기록하며 null을 반환합니다.
+     * 이는 재전송 로직이나 스케줄링에서 사용되며, 별도 트랜잭션이 적용되지 않습니다.</p>
+     *
+     * <p>동작 순서:
+     * <ol>
+     *     <li>RedisTemplate의 opsForList().rightPop()를 호출하여 큐에서 꺼냅니다.</li>
+     *     <li>요청이 null이 아니면 로그를 남깁니다.</li>
+     *     <li>예외 발생 시 null을 반환합니다.</li>
+     * </ol>
+     * </p>
+     *
+     *
+     * @return dequeue된 알림 요청 DTO, 큐가 비어 있거나 실패 시 null
+     * @see RedisTemplate#opsForList()
+     */
+    // 큐에서 항목을 꺼내는 메서드
+    public NotificationRequestDto dequeueNotification() {
+        try {
+            NotificationRequestDto request = redisTemplate.opsForList().rightPop(QUEUE_KEY);
+            if (request != null) {
+                log.info("Redis 큐에서 알림 요청 꺼냄: {}", request.getContent());
+            }
+            return request;
+        } catch (Exception e) {
+            log.error("Redis 큐에서 제거 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationFallbackFactory.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationFallbackFactory.java
@@ -1,0 +1,86 @@
+package com.grow.matching_service.matching.presentation.client;
+
+import com.grow.matching_service.matching.application.service.QueueService;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.openfeign.FallbackFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeoutException;
+
+/**
+ * NotificationServiceClient의 FallbackFactory 구현 클래스.
+ * 이 클래스는 NotificationServiceClient가 실패할 경우 대체 로직을 제공합니다.
+ * 주로 Circuit Breaker, Feign 예외, 타임아웃 등의 장애 상황에서 알림 요청을 큐에 저장하여 후속 처리를 보장합니다.
+ *
+ * <p>이 구현은 Spring Cloud Circuit Breaker (Resilience4j)와 Feign 클라이언트를 기반으로 하며,
+ * 장애 발생 시 로그를 기록하고 요청을 QueueService로 전달합니다.</p>
+ *
+ * @see io.github.resilience4j.circuitbreaker.CallNotPermittedException
+ * @see feign.FeignException
+ * @see java.util.concurrent.TimeoutException
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationFallbackFactory implements FallbackFactory<NotificationServiceClient> {
+
+    private final QueueService queueService;
+
+    /**
+     * TODO 장애 대응을 위해 메트릭 서비스 추가할 것 (모니터링 용도)
+     * 예: Prometheus나 Micrometer를 사용하여 실패 횟수, 지연 시간 등을 모니터링.
+     */
+
+    /**
+     * Fallback 인스턴스를 생성합니다.
+     * Throwable cause에 따라 적절한 예외 처리를 수행한 후, 요청을 큐에 저장합니다.
+     *
+     * @param cause 발생한 예외 (Circuit Breaker, Feign, Timeout 등)
+     * @return NotificationServiceClient의 대체 구현 (람다 표현식으로 요청 처리)
+     */
+    @Override
+    public NotificationServiceClient create(Throwable cause) {
+        return request -> {
+            switch (cause) {
+                case CallNotPermittedException callNotPermittedException ->
+                        handleExceptions("Circuit Breaker OPEN 상태: {}", cause);  // Circuit Breaker가 열린 상태로 인해 호출 불가
+                case FeignException feignEx -> handleFeignException(feignEx);  // Feign 클라이언트 예외 처리 (Retry 실패 등)
+                case TimeoutException timeoutException ->   // 타임아웃 예외
+                        handleExceptions("타임아웃 오류: {}", cause);  // 요청 시간이 초과된 경우
+                default -> handleExceptions("기타 오류: {}", cause);  // 예상치 못한 다른 예외
+            }
+
+            queueService.enqueueNotification(request);  // 별도 큐 서비스로 저장하여 후속 처리 보장
+            log.info("알림을 큐에 저장: 후속 처리 예정");
+        };
+    }
+
+    /**
+     * FeignException을 처리합니다.
+     * HTTP 상태 코드를 로그로 기록하며, 503 (Service Unavailable)인 경우 특별 경고를 추가합니다.
+     *
+     * @param feignEx 발생한 FeignException 인스턴스
+     */
+    private void handleFeignException(FeignException feignEx) {
+        log.error("Feign 오류 (Retry 실패): HTTP {} - {}",
+                feignEx.status(), feignEx.getMessage());
+        // HTTP 503 (Service Unavailable)인 경우 특별 처리
+        if (feignEx.status() == 503) {
+            log.warn("서비스 이용 불가: 복구 대기 중");
+        }
+    }
+
+    /**
+     * 일반 예외를 처리합니다.
+     * 주어진 메시지 형식으로 로그를 기록합니다.
+     *
+     * @param s 로그 메시지 형식 문자열 (예: "타임아웃 오류: {}")
+     * @param cause 발생한 Throwable 인스턴스
+     */
+    private void handleExceptions(String s, Throwable cause) {
+        log.error(s, cause.getMessage());
+    }
+}

--- a/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationServiceClient.java
+++ b/src/main/java/com/grow/matching_service/matching/presentation/client/NotificationServiceClient.java
@@ -1,20 +1,57 @@
 package com.grow.matching_service.matching.presentation.client;
 
 import com.grow.matching_service.matching.application.dto.NotificationRequestDto;
+import feign.FeignException;
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 /**
- * @FeignClient 클라이언트 이름과 URL을 지정
- * 1. NotificationServiceClient 를 @Autowired
- * 2. sendNotification 메서드 호출하면서 dto 를 전송하면
- * 3. 자동으로 notification-service 에게 요청을 보낸다
+ * 알림 서비스(notification-service)와 통신하기 위한 Feign 클라이언트 인터페이스.
+ * 이 인터페이스는 외부 알림 서비스로 알림 요청을 전송하며, Spring Cloud OpenFeign을 기반으로 합니다.
+ *
+ * <p>주요 설정:</p>
+ * <ul>
+ *   <li>name: "notification-service" - 서버 이름 지정.</li>
+ *   <li>url: "${notification.service.url}" - 프로퍼티에서 동적으로 URL 설정 (application.yml).</li>
+ *   <li>fallback: NotificationFallbackFactory.class - 장애 시 fallback 로직 실행 (큐 저장).</li>
+ *   <li>@Retry: "notificationRetry" - 재시도 정책 적용 (Resilience4j).</li>
+ *   <li>@CircuitBreaker: "notificationCircuitBreaker" - 서킷 브레이커 적용 (장애 시 호출 차단).</li>
+ * </ul>
+ *
+ * <p>사용 방법:</p>
+ * <ol>
+ *   <li>이 인터페이스를 @Autowired로 주입합니다.</li>
+ *   <li>sendNotification 메서드를 호출하여 NotificationRequestDto를 전송합니다.</li>
+ *   <li>자동으로 notification-service의 /notifications 엔드포인트로 POST 요청을 보냅니다.</li>
+ * </ol>
+ *
+ * @see org.springframework.cloud.openfeign.FeignClient
+ * @see io.github.resilience4j.retry.annotation.Retry
+ * @see io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+ * @see NotificationFallbackFactory  // fallback 구현 클래스
+ * @see NotificationRequestDto  // 요청 DTO 클래스
  */
 @FeignClient(name = "notification-service",
-        url = "${notification.service.url}")
+        url = "${notification.service.url}",
+        fallback = NotificationFallbackFactory.class) // fallback 클래스 지정
+@Retry(name = "notificationRetry")  // 재시도 정책 설정 (Resilience4j)
+@CircuitBreaker(name = "notificationCircuitBreaker")  // circuit breaker 설정 (Resilience4j)
 public interface NotificationServiceClient {
 
+    /**
+     * 알림을 외부 서비스로 전송합니다.
+     * notification-service의 /notifications 엔드포인트로 POST 요청을 보내 알림을 처리합니다.
+     *
+     * <p>장애 발생 시 (예: 타임아웃, 5xx 오류) fallbackFactory가 호출되어 큐에 저장됩니다.</p>
+     *
+     * @param request 알림 요청 데이터 (NotificationRequestDto 객체)
+     * @throws FeignException Feign 클라이언트 오류 발생 시 (예: HTTP 오류)
+     * @throws CallNotPermittedException Circuit Breaker가 OPEN 상태일 때
+     */
     @PostMapping("/notifications")
     void sendNotification(@RequestBody NotificationRequestDto request);
 }


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 빌드 실행 확인했습니다

+ 📸 Screenshot or Test Result
<img width="645" height="253" alt="스크린샷 2025-07-25 오후 4 59 15" src="https://github.com/user-attachments/assets/3e2c6b2b-f403-410c-b160-1cb3b09ebe5d" />

## 📝 Note (주의 사항)
1. 재시도, 서킷 브레이커 로직을 추가했습니다 (반대쪽 서버에서 수신하지 못했을 경우를 가정함)
2. wiremock 추가해서 feign 으로 보낸 것을 모킹하여, 실제 적용되는지 테스트 진행했습니다 (성공 응답, 재시도, 서킷 브레이커 열렸을 경우)
3. 이후 notification-service 에서 정보를 받아 DB에 저장하고 클라이언트에 sse 로 전송할 수 있도록 추가할 예정입니다
4. 그 다음에 프론트 만져야겠네요... 
5. 모니터링 및 AOP 적용하여 성능 확인하는 부분은 나중에 성능 테스트 하며 추가하겠습니다 ^^