### PR TITLE
✨ feat: 쿼리 로직 추가 기능 구현 #29

### DIFF
--- a/src/main/java/com/grow/matching_service/matching/application/config/RedisConfig.java
+++ b/src/main/java/com/grow/matching_service/matching/application/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -49,6 +50,30 @@ public class RedisConfig {
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer()); // String 값용
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Boolean> customBooleanRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Boolean> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Boolean.class));
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Double> customDoubleRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Double> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Double.class));
 
         template.afterPropertiesSet();
         return template;

--- a/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepositoryImpl.java
+++ b/src/main/java/com/grow/matching_service/matching/infra/repository/MatchingQueryRepositoryImpl.java
@@ -10,32 +10,50 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.Comparator;
 import java.util.List;
 
 /**
  * <h2>사용자 매칭 전용 QueryDSL 레포지토리</h2>
  *
  * <p>기준 사용자가 속한 카테고리 내에서 아래 규칙으로 유사도 점수를 계산해
- * 1 점 이상인 사용자 목록을 반환함 </p>
+ * 1 점 이상인 사용자 목록을 반환함. 결과가 20명 이하인 경우 그대로 반환하나,
+ * 20명 초과 시 Redis 캐시에서 신뢰도 점수와 구독 여부를 조회하여 재정렬 후 상위 20명만 선별함.</p>
  *
  * <ol>
  *   <li>카테고리: 반드시 동일 (조건 필수)</li>
  *   <li>mostActiveTime · level · age · isAttending
  *       – 속성이 일치할 때마다 1 점 가산 (최대 4 점)</li>
  *   <li>본인은 제외하고, 점수 내림차순 정렬</li>
+ *   <li>결과가 20명 초과 시 추가 정렬:
+ *       <ul>
+ *         <li>Redis 신뢰도 점수 내림차순 (높은 점수 우선)</li>
+ *         <li>신뢰도 점수가 동일할 경우, 구독 여부 내림차순 (구독한 사용자 우선)</li>
+ *       </ul>
+ *       상위 20명만 반환 (Redis 키: "member:trust:score:{memberId}" 및 "member:subscription:{memberId}")
+ *   </li>
  * </ol>
  *
- * @author sun
  * @since 2025.07.15
  */
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class MatchingQueryRepositoryImpl implements MatchingQueryRepository {
 
     private final JPAQueryFactory factory;
+    private final RedisTemplate<String, Boolean> booleanRedisTemplate; // 구독 여부 캐싱
+    private final RedisTemplate<String, Double> doubleRedisTemplate; // 신뢰도 점수 캐싱
+
+    public static final String TRUST_KEY = "member:trust:score:";
+    public static final String SUB_KEY = "member:subscription:";
 
     /**
      * 기준 엔티티와 유사한 사용자 목록을 조회한다.
@@ -55,7 +73,7 @@ public class MatchingQueryRepositoryImpl implements MatchingQueryRepository {
         // 0~4점 범위의 동적 점수 계산 (CaseBuilder 사용)
         NumberExpression<Integer> score = buildScoreExpression(reference, target);
 
-        return factory
+        List<MatchingResult> candidates = factory
                 .select(Projections.constructor(MatchingResult.class,
                         target.memberId,
                         target.category,
@@ -74,9 +92,18 @@ public class MatchingQueryRepositoryImpl implements MatchingQueryRepository {
                         score.goe(1)                              // 1점 이상
                 )
                 .orderBy(score.desc()) // 점수 내림차순 정렬 (높은 순서부터)
-                .limit(20) // 20 개 한정으로 보여 주기
                 .fetch();
+
+        // 20명 이상일 경우 redis 기반으로 정렬
+        if (candidates.size() > 20) {
+            log.info("[Matching-Query] 20명 이상의 유사도 점수가 있는 사용자가 존재합니다. Redis 캐시를 조회합니다.");
+            candidates = sortCandidatesByTrustAndSubscription(candidates);
+            candidates = candidates.subList(0, Math.min(20, candidates.size())); // 상위 20명 추출
+        }
+
+        return candidates;
     }
+
     /**
      * 각 속성 일치 시 1 점을 가산하는 점수 식을 생성한다.
      *
@@ -94,5 +121,80 @@ public class MatchingQueryRepositoryImpl implements MatchingQueryRepository {
                         .when(target.age.eq(ref.getAge())).then(1).otherwise(0))
                 .add(new CaseBuilder()
                         .when(target.isAttending.eq(ref.getIsAttending())).then(1).otherwise(0));
+    }
+
+    /**
+     * Redis 캐시에서 각 후보의 신뢰도 점수(trust score)와 구독 여부(subscription status)를 조회하여,
+     * 후보 목록을 정렬합니다. 정렬 기준은 다음과 같습니다:
+     * <ul>
+     *     <li>신뢰도 점수 내림차순 (높은 점수가 우선)</li>
+     *     <li>신뢰도 점수가 동일할 경우, 구독 여부 내림차순 (구독한 사용자(true)가 우선)</li>
+     * </ul>
+     * Redis 키는 다음과 같이 가정합니다:
+     * <ul>
+     *     <li>신뢰도 점수 키: "member:trust:score:{memberId}" (값: Double)</li>
+     *     <li>구독 여부 키: "member:subscription:{memberId}" (값: Boolean)</li>
+     * </ul>
+     * 캐시 미스(값이 없을 경우) 신뢰도 점수는 0.0으로, 구독 여부는 false로 기본 처리합니다.
+     *
+     * @param candidates 정렬할 MatchingResult 후보 목록 (각 항목에 memberId가 포함되어 있어야 함)
+     * @return 정렬된 MatchingResult 목록 (원본 목록과 동일한 타입)
+     * @see MatchingResult MatchingResult DTO 클래스
+     * @see CandidateWithScore 내부 헬퍼 클래스 (정렬을 위한 임시 wrapper)
+     */
+    // TODO Redis 연결 실패 또는 조회 오류 시 발생할 수 있음 (try-catch로 변경하는 게 나을지?)
+    private List<MatchingResult> sortCandidatesByTrustAndSubscription(List<MatchingResult> candidates) {
+        return candidates.stream()
+                .map(candidate -> {
+                    Long memberId = candidate.getMemberId();
+
+                    // Redis 에서 신뢰도 점수 가져오기 (없으면 0으로 기본값 설정)
+                    Double trustScore = doubleRedisTemplate
+                            .opsForValue()
+                            .get(TRUST_KEY + memberId);
+                    if (trustScore == null) {
+                        trustScore = 0.0;
+                        log.warn("[Matching-Query] Redis 신뢰도 점수 없음: {}", memberId);
+                    }
+
+                    // Redis 에서 구독 여부 가져오기 (없으면 false)
+                    Boolean isSubscribed = booleanRedisTemplate
+                            .opsForValue()
+                            .get(SUB_KEY + memberId);
+                    if (isSubscribed == null) {
+                        isSubscribed = false;
+                        log.warn("[Matching-Query] Redis 구독 여부 없음: {}", memberId);
+                    }
+
+                    // 임시 CandidateWithScore 객체 생성: 정렬을 위해 신뢰도와 구독 정보를 함께 묶음
+                    return new CandidateWithScore(
+                            candidate,
+                            trustScore,
+                            isSubscribed
+                    );
+                })
+                .sorted(Comparator.comparingDouble(CandidateWithScore::getTrustScore)
+                        .reversed() // 1차 정렬: 신뢰도 점수 내림차순 (높은 점수 우선)
+                        .thenComparing(
+                                CandidateWithScore::isSubscribed,
+                                Comparator.reverseOrder()
+                        ) // 2차 정렬: 구독 여부 내림차순 (true가 false보다 우선)
+                )
+                .map(CandidateWithScore::getCandidate) // 정렬 후 원본 MatchingResult만 추출 (wrapper 제거)
+                .toList(); // 최종 리스트로 변환
+    }
+
+    /**
+     * 정렬을 위한 임시 wrapper 클래스. MatchingResult에 신뢰도 점수와 구독 여부를 추가로 저장합니다.
+     * 이 클래스는 sortCandidatesByTrustAndSubscription 메서드 내에서만 사용되며, 메모리 효율을 위해 static으로 정의.
+     *
+     * @see MatchingResult 원본 DTO
+     */
+    @Getter
+    @AllArgsConstructor
+    private static class CandidateWithScore {
+        private final MatchingResult candidate;
+        private final double trustScore;
+        private final boolean isSubscribed;
     }
 }

--- a/src/test/java/com/grow/matching_service/matching/infra/persistence/repository/MatchingQueryRedisTest.java
+++ b/src/test/java/com/grow/matching_service/matching/infra/persistence/repository/MatchingQueryRedisTest.java
@@ -1,0 +1,177 @@
+package com.grow.matching_service.matching.infra.persistence.repository;
+
+import com.grow.matching_service.matching.domain.enums.Age;
+import com.grow.matching_service.matching.domain.enums.Category;
+import com.grow.matching_service.matching.domain.enums.Level;
+import com.grow.matching_service.matching.domain.enums.MostActiveTime;
+import com.grow.matching_service.matching.infra.dto.MatchingQueryDto;
+import com.grow.matching_service.matching.infra.dto.MatchingResult;
+import com.grow.matching_service.matching.infra.entity.MatchingJpaEntity;
+import com.grow.matching_service.matching.infra.repository.MatchingQueryRepositoryImpl;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+public class MatchingQueryRedisTest {
+
+    @Autowired
+    private MatchingQueryRepositoryImpl matchingQueryRepository; // 테스트 대상
+
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private RedisTemplate<String, Boolean> booleanRedisTemplate; // 구독 여부 캐싱
+
+    @Autowired
+    private RedisTemplate<String, Double> doubleRedisTemplate; // 신뢰도 점수 캐싱
+
+    private MatchingQueryDto baseDto;
+
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 Redis 캐시 초기화 (기존 데이터 삭제)
+        booleanRedisTemplate.getConnectionFactory().getConnection().flushDb();
+        doubleRedisTemplate.getConnectionFactory().getConnection().flushDb();
+
+        // 샘플 Redis 데이터 세팅 (테스트용 멤버 ID: 2~25 가정, 25명 후보 시뮬레이션)
+        // 신뢰도 점수와 구독 여부 설정 (예: 높은 신뢰도 우선, 같은 점수 시 구독 우선)
+        for (long i = 2; i <= 26; i++) {
+            String trustKey = "member:trust:score:" + i;
+            String subKey = "member:subscription:" + i;
+
+            // 예시 데이터: ID 2~10: 고신뢰도(90점대), ID 11~25: 저신뢰도(50~26), 구독 random
+            int groupIndex = (int) Math.ceil((i - 1) / 2.0); // (2-3: group1, 4-5: group2, ..., 24-25: group12, 26: group13)
+            double trustScore;
+            if (i <= 10) {
+                // 고신뢰 그룹: 그룹별로 99, 98, ..., 95 (감소 단위 1.0) (동점 만들기)
+                trustScore = 100 - groupIndex * 1.0;  // 2-3:99, 4-5:98, 6-7:97, 8-9:96, 10:95 (10은 단독, group5)
+            } else {
+                // 저신뢰 그룹: 그룹별로 59, 58, ..., ~ (11-12:59, 13-14:58, ..., 24-25:52, 26:51)
+                int lowGroupIndex = (int) Math.ceil((i - 9) / 2.0);
+                trustScore = 60 - lowGroupIndex * 1.0;
+            }
+
+            boolean isSubscribed = (i % 2 == 0);  // 짝수 ID: 구독 true, 홀수: false
+
+            log.info("[redis cache] memberId: {}, trustScore: {}, isSubscribed: {}", i, trustScore, isSubscribed);
+
+            doubleRedisTemplate.opsForValue().set(trustKey, trustScore);
+            booleanRedisTemplate.opsForValue().set(subKey, isSubscribed);
+        }
+
+        baseDto = MatchingQueryDto.builder()
+                .memberId(1L)  // 본인 memberId (본인 제외 로직 테스트)
+                .category(Category.STUDY)  // 카테고리 예시 (enum 가정)
+                .mostActiveTime(MostActiveTime.MORNING)
+                .level(Level.SEED)
+                .age(Age.NONE)
+                .isAttending(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("매칭된 사용자가 20명 이하인 경우에는 그대로 전부 출력된다")
+    void findMatchingV1() throws Exception {
+        // Given: 기준 사용자 설정 -> setUp 에서 실행
+        // DB에 10명 테스트 데이터 삽입 (유사도 점수 계산을 위한 데이터: 일부 속성 일치)
+        for (long i = 2; i <= 11; i++) {
+            MatchingJpaEntity entity = MatchingJpaEntity.builder()
+                    .memberId(i)
+                    .category(Category.STUDY)  // 카테고리 동일
+                    .mostActiveTime(MostActiveTime.MORNING) // 일치 -> 무조건 1점은 얻을 수 있음
+                    .level(i % 5 == 0 ? Level.SEED : Level.FRUITFUL) // 일부 일치
+                    .age(i % 2 == 0 ? Age.TWENTIES : Age.THIRTIES) // 나이 선택하지 않았을 경우에 점수에 포함되지 않음
+                    .isAttending(i % 5 == 0)
+                    .build();
+            em.persist(entity);
+        }
+        em.flush();  // DB 반영
+
+        Thread.sleep(1000); // 별도 스레드에서 전부 실행될 시간을 기다림
+
+        // When
+        List<MatchingResult> results = matchingQueryRepository.findMatchingUsers(baseDto);
+
+        // Then: 20명 이하이므로 캐싱 추가 정렬 없이 그대로 반환 (크기 확인)
+        assertThat(results).hasSize(10);  // 정확한 크기 검증 (삽입한 10명)
+
+        // 추가 검증: 유사도 점수 내림차순 정렬 확인
+        for (int i = 0; i < results.size() - 1; i++) {
+            double currentScore = results.get(i).getScore();  // getScore() 가정 (유사도 점수 필드)
+            double nextScore = results.get(i + 1).getScore();
+            assertThat(currentScore).isGreaterThanOrEqualTo(nextScore);  // 내림차순 확인
+        }
+
+        // 추가 검증: 최소 1점 이상 (쿼리 조건 확인)
+        assertThat(results).allMatch(result -> result.getScore() >= 1);
+    }
+
+    @Test
+    @DisplayName("매칭된 사용자가 20명 이상인 경우에는 추가 검증 로직이 동작한다")
+    void findMatchingV2() throws Exception {
+        // Given: 기준 사용자 설정 -> setUp 에서 실행
+        // 25명 후보 시뮬레이션
+        for (long i = 2; i <= 26; i++) {
+            MatchingJpaEntity entity = MatchingJpaEntity.builder()
+                    .memberId(i)
+                    .category(Category.STUDY)  // 카테고리 동일
+                    .mostActiveTime(MostActiveTime.MORNING) // 일치 -> 무조건 1점은 얻을 수 있음
+                    .level(i % 5 == 0 ? Level.SEED : Level.FRUITFUL) // 일부 일치
+                    .age(i % 2 == 0 ? Age.TWENTIES : Age.THIRTIES) // 나이 선택하지 않았을 경우에 점수에 포함되지 않음
+                    .isAttending(i % 5 == 0)
+                    .build();
+            em.persist(entity);
+        }
+        em.flush();  // DB 반영
+
+        Thread.sleep(1000); // 별도 스레드에서 전부 실행될 시간을 기다림
+
+        // When
+        List<MatchingResult> results = matchingQueryRepository.findMatchingUsers(baseDto);
+
+        // Then: 상위 20명만 반환, 정렬 기준 확인
+        assertThat(results).hasSize(20);
+
+        // 정렬 검증: 첫 번째는 최고 신뢰도 + 구독 true (ID 2: 99.0, 구독 true)
+        assertThat(results.getFirst().getMemberId()).isEqualTo(2L);
+
+        // 두 번째: ID 3 (99.0, 구독 false) – ID 2 보다 뒤에 위치하는가
+        assertThat(results.get(1).getMemberId()).isEqualTo(3L);
+
+        // 전체 정렬 순서 확인 (신뢰도 내림차순, 같은 점수 시 구독 우선)
+        for (int i = 0; i < 19; i++) {
+            MatchingResult current = results.get(i);
+            MatchingResult next = results.get(i + 1);
+
+            // 신뢰도 비교 (또는 같으면 구독 비교)
+            double currentTrust = doubleRedisTemplate.opsForValue().get("member:trust:score:" + current.getMemberId());
+            double nextTrust = doubleRedisTemplate.opsForValue().get("member:trust:score:" + next.getMemberId());
+
+            boolean currentSub = booleanRedisTemplate.opsForValue().get("member:subscription:" + current.getMemberId());
+            boolean nextSub = booleanRedisTemplate.opsForValue().get("member:subscription:" + next.getMemberId());
+
+            if (currentTrust == nextTrust) {  // 신뢰도 동일
+                // boolean 비교: true를 1, false를 0으로 변환하여 >= 확인 (true >= false)
+                assertThat(currentSub ? 1 : 0).isGreaterThanOrEqualTo(nextSub ? 1 : 0);
+            } else {
+                assertThat(currentTrust).isGreaterThan(nextTrust);  // 내림차순 확인
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✅ Check List(필수)
- [ ] 코드에 주석 추가 완료
- [ ] 테스트 통과 확인 (`npm test`)

+ 📸 Screenshot or Test Result

<img width="625" height="418" alt="스크린샷 2025-07-28 오후 6 04 08" src="https://github.com/user-attachments/assets/9cf9dd77-b6b7-4d9a-804f-40b15a300606" />
<img width="476" height="78" alt="스크린샷 2025-07-28 오후 6 04 36" src="https://github.com/user-attachments/assets/8aab9fa7-c393-4c2e-858b-523467ffa933" />
- 실제 redis 에는 위와 같은 형식으로 캐싱 되었다고 가정합니다

<img width="940" height="107" alt="스크린샷 2025-07-28 오후 6 04 46" src="https://github.com/user-attachments/assets/00dec4b9-c7fb-4fcb-bec1-89e627ebf02e" />
- redis 에 들어있는 데이터와 일치 확인

<img width="907" height="91" alt="스크린샷 2025-07-28 오후 6 04 59" src="https://github.com/user-attachments/assets/a0b1bb77-ed55-41ad-99fd-3aa523ce8867" />
- 20 명 이상의 매칭 사용자가 생성됐을 경우 log 출력 + 로직 추가 실행

<img width="755" height="188" alt="스크린샷 2025-07-28 오후 6 16 21" src="https://github.com/user-attachments/assets/309d277a-a1c2-431a-8d8c-96f032e56126" />
- 같은 점수, 구독 여부만 다른 사용자를 기본 세팅

<img width="655" height="204" alt="스크린샷 2025-07-28 오후 6 27 33" src="https://github.com/user-attachments/assets/2c241f13-af51-4217-a626-f90c6b9fd020" />
- 테스트 통과 ^^~!

## 📝 Note (주의 사항)
제안 주셨던 것과 같이 1. 신뢰도 점수 필터링 2. 만약 신뢰도 점수가 같은 경우에는 구독자 우선으로 필터링 진행했습니다
이 정도면 뭔가 매칭은 그래도... 얼추 마무리 된 것 같기도 하고요 아닌 것 같기도 하고요...
추후에는 알림 전송되는 것 받아서 알림 서버에서 클라이언트로 전송하는 부분 끝내 보겠습니다 그리고 프론트!!! ^ ^ 
